### PR TITLE
feat: enhance ExpressiveCode with line numbers

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@expressive-code/plugin-collapsible-sections':
         specifier: ^0.41.2
         version: 0.41.2
+      '@expressive-code/plugin-line-numbers':
+        specifier: ^0.41.2
+        version: 0.41.2
       '@fontsource-variable/big-shoulders-display':
         specifier: ^5.0.20
         version: 5.1.1
@@ -374,6 +377,9 @@ packages:
 
   '@expressive-code/plugin-frames@0.41.2':
     resolution: {integrity: sha512-pfy0hkJI4nbaONjmksFDcuHmIuyPTFmi1JpABe4q2ajskiJtfBf+WDAL2pg595R9JNoPrrH5+aT9lbkx2noicw==}
+
+  '@expressive-code/plugin-line-numbers@0.41.2':
+    resolution: {integrity: sha512-xdRoScuFWQbYEpWTh6G7kJ0VK46kcUPHPMjRo3CG2ynZ1rqiJCC9FnZQQWQ7U8aGd/n7EnU3vJBkBeVqhZyEWg==}
 
   '@expressive-code/plugin-shiki@0.41.2':
     resolution: {integrity: sha512-xD4zwqAkDccXqye+235BH5bN038jYiSMLfUrCOmMlzxPDGWdxJDk5z4uUB/aLfivEF2tXyO2zyaarL3Oqht0fQ==}
@@ -2894,6 +2900,10 @@ snapshots:
       '@expressive-code/core': 0.41.2
 
   '@expressive-code/plugin-frames@0.41.2':
+    dependencies:
+      '@expressive-code/core': 0.41.2
+
+  '@expressive-code/plugin-line-numbers@0.41.2':
     dependencies:
       '@expressive-code/core': 0.41.2
 

--- a/starlight/astro.config.mjs
+++ b/starlight/astro.config.mjs
@@ -1,5 +1,4 @@
 import starlight from "@astrojs/starlight";
-import { pluginCollapsibleSections } from "@expressive-code/plugin-collapsible-sections";
 import { defineConfig } from "astro/config";
 import starlightBlog from "starlight-blog";
 import starlightImageZoom from "starlight-image-zoom";
@@ -127,9 +126,6 @@ export default defineConfig({
       ],
       pagination: false,
       credits: true,
-      expressiveCode: {
-        plugins: [pluginCollapsibleSections()],
-      },
     }),
   ],
   redirects: {

--- a/starlight/ec.config.mjs
+++ b/starlight/ec.config.mjs
@@ -1,0 +1,17 @@
+import { pluginCollapsibleSections } from "@expressive-code/plugin-collapsible-sections";
+import { pluginLineNumbers } from "@expressive-code/plugin-line-numbers";
+
+/** @type {import('@astrojs/starlight/expressive-code').StarlightExpressiveCodeOptions} */
+export default {
+  plugins: [pluginLineNumbers(), pluginCollapsibleSections()],
+  defaultProps: {
+    // Enable line numbers by default
+    showLineNumbers: true,
+    // But disable line numbers for certain languages
+    overridesByLang: {
+      bash: {
+        showLineNumbers: false,
+      },
+    },
+  },
+};

--- a/starlight/package.json
+++ b/starlight/package.json
@@ -13,6 +13,7 @@
     "@astrojs/check": "^0.9.4",
     "@astrojs/starlight": "^0.34.3",
     "@expressive-code/plugin-collapsible-sections": "^0.41.2",
+    "@expressive-code/plugin-line-numbers": "^0.41.2",
     "@fontsource-variable/big-shoulders-display": "^5.0.20",
     "@fontsource-variable/ibarra-real-nova": "^5.0.21",
     "@fontsource-variable/jetbrains-mono": "^5.0.21",

--- a/starlight/src/content/docs/blog/starlight-dropdown-and-list-together.mdx
+++ b/starlight/src/content/docs/blog/starlight-dropdown-and-list-together.mdx
@@ -32,7 +32,7 @@ First, install the `starlight-sidebar-topics` plugin and also the `starlight-sid
 
 <TabItem label="npm">
 
-```sh
+```bash
 npm install starlight-sidebar-topics starlight-sidebar-topics-dropdown
 ```
 
@@ -40,7 +40,7 @@ npm install starlight-sidebar-topics starlight-sidebar-topics-dropdown
 
 <TabItem label="pnpm">
 
-```sh
+```bash
 pnpm add starlight-sidebar-topics starlight-sidebar-topics-dropdown
 ```
 
@@ -48,7 +48,7 @@ pnpm add starlight-sidebar-topics starlight-sidebar-topics-dropdown
 
 <TabItem label="Yarn">
 
-```sh
+```bash
 yarn add starlight-sidebar-topics starlight-sidebar-topics-dropdown
 ```
 

--- a/starlight/src/content/docs/blog/starlight-sidebar-whitespace.md
+++ b/starlight/src/content/docs/blog/starlight-sidebar-whitespace.md
@@ -57,7 +57,7 @@ But before I do that, I'll show you how the default styling of the Starlight sid
 
 On the root level of your Starlight sidebar, there are two different types of elements: **pages** and **groups**. While the default styling is pretty decent, I found the whitespaces - this is the margin between items which itself doesn't include any content - to be a bit too large, especially between root-level items. With this example of custom CSS down below, I made the margin between root-level items smaller while keeping the margin between groups the same. The important CSS styling is highlighted in the code block.
 
-```css {3}
+```css {3} showLineNumbers=false
 // src/styles/custom.css
 sl-sidebar-state-persist ul.top-level > li:not(:has(details)) {
   margin-top: 0rem;
@@ -75,7 +75,7 @@ Perhaps, this will not be as useful to you because you don't use root-level page
 
 [Imho][imho] the one thing that triggers me the most about Starlight's root-level items in the sidebar, is their boldness. This is probably a very opinionated take, but if you ask me, one single page can't possibly be as important as an entire group of pages in your documentation. Therefore, I made the font weight of root-level items thinner as you can see in the code block below.
 
-```css {6}
+```css {6} showLineNumbers=false
 // src/styles/custom.css
 sl-sidebar-state-persist ul.top-level > li > a[aria-current="page"] {
   font-weight: 600; /* default value */
@@ -92,7 +92,8 @@ sl-sidebar-state-persist ul.top-level > li > a:not([aria-current="page"]) {
 A small but subtle change: I made unselected root-level items appear dimmer in the code block below.
 
 If you choose to use this design as well, I recommend that you only apply the second CSS manipulation since the first one is just for demonstrating how you could adjust the styling of selected root-level items – this rule also applies to the other code blocks in this blog if they are marked as `default value`.
-```css {6}
+
+```css {6} showLineNumbers=false
 // src/styles/custom.css
 sl-sidebar-state-persist ul.top-level > li > a[aria-current="page"] {
   color: var(--sl-color-text-invert); /* default value */
@@ -108,7 +109,7 @@ sl-sidebar-state-persist ul.top-level > li > a:not([aria-current="page"]) {
 
 Although I don't recommend it, you can also adjust the font size of sidebar items. With this example of custom CSS down below, I made the font size of root-level items smaller.
 
-```css {3}
+```css {3} showLineNumbers=false
 // src/styles/custom.css
 sl-sidebar-state-persist ul.top-level > li > a {
   font-size: var(--sl-text-sm);
@@ -123,7 +124,7 @@ Summing everything up, I recommend that you apply some mix of the above customiz
 
 Note that I also use [Cascade Layers][starlight-css-cascade-layers], supported since [Starlight 0.34.0][starlight-0-34], and recommend using them to specify the order in which CSS styles are applied.
 
-```css
+```css showLineNumbers=false
 // src/styles/custom.css
 @layer starlight, my-starlight-sidebar;
 

--- a/starlight/src/content/docs/blog/technically-impressive-github-profile-readme.mdx
+++ b/starlight/src/content/docs/blog/technically-impressive-github-profile-readme.mdx
@@ -44,7 +44,7 @@ I tried tweaking it. Replacing unsupported tags with ones that worked. Maybe I c
 
 When in doubt, automate. If I couldn’t get my HTML in directly, maybe I could generate something dynamic with a script? So I threw together a Python script to fetch my latest GitHub repository and insert it into my README. Just leaving this random bytes which some would call Python code here:
 
-```python collapse={1-22}
+```python collapse={1-22} showLineNumbers=false
 import requests
 
 github_username = "yourusername"
@@ -91,7 +91,7 @@ SVGs could scale, they supported both text and images, and — most importantly 
 
 So I tried something like this:
 
-```xml
+```xml showLineNumbers=false
 <svg width="800" height="400" xmlns="http://www.w3.org/2000/svg">
   <foreignObject width="100%" height="100%">
     <body xmlns="http://www.w3.org/1999/xhtml">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enabled line numbers by default for code blocks, except for Bash code, where line numbers are hidden.
- **Bug Fixes**
  - Updated code blocks in documentation to use the correct language tag (`bash` instead of `sh`).
- **Style**
  - Disabled line numbers for specific CSS, Python, and XML code blocks in blog posts for improved readability.
- **Chores**
  - Added a new dependency for line number support in code blocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->